### PR TITLE
bump filestack version

### DIFF
--- a/addon/helpers/filestack-image.js
+++ b/addon/helpers/filestack-image.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+
+const {
+	computed,
+	computed: { alias },
+	getOwner,
+	Helper,
+} = Ember;
+
+export default Helper.extend({
+  config: computed(function() {
+    return getOwner(this).resolveRegistration('config:environment');
+  }),
+	key: alias('config.filestackKey'),
+  compute([token], hash) {
+    let options = [];
+    let resizeOptions, urlRoot;
+    if(!token) {
+      return '';
+    }
+    Object.keys(hash).forEach((key) => {
+      let value = hash[key];
+      if(value) {
+        options.push(`${key}:${value}`)
+      }
+    });
+
+    if(options.length >= 1) {
+      resizeOptions = `resize=${options.join(',')}`
+    } else {
+      resizeOptions = null
+    }
+
+    if(token.match(/http(s?):\/\//)) {
+      urlRoot = `https://process.filestackapi.com/${this.get('key')}`;
+    } else {
+      urlRoot = 'https://process.filestackapi.com';
+    }
+    return [
+      urlRoot,
+      resizeOptions,
+      token,
+    ].filter((element) => {
+      return element;
+    }).join('/')
+    // return .compact().join('/')
+  }
+});

--- a/app/helpers/filestack-image.js
+++ b/app/helpers/filestack-image.js
@@ -1,0 +1,1 @@
+export { default, filestackImage } from 'ember-filestack/helpers/filestack-image';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "filestack-js": "^0.6.0",
+    "filestack-js": "^0.9.0",
     "ember-cli-babel": "^6.0.0"
   },
   "devDependencies": {

--- a/tests/integration/helpers/filestack-image-test.js
+++ b/tests/integration/helpers/filestack-image-test.js
@@ -1,0 +1,41 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('filestack-image', 'helper:filestack-image', {
+  integration: true
+});
+
+// Replace this with your real tests.
+test('it renders a resize with options', function(assert) {
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken width='200' height='300' fit='crop'}}`);
+  let expected = 'https://process.filestackapi.com/resize=width:200,height:300,fit:crop/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});
+
+test('it renders a resize without options', function(assert) {
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken}}`);
+  let expected = 'https://process.filestackapi.com/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});
+
+test('it handles urls', function(assert) {
+  this.set('imageToken', 'https://d1wtqaffaaj63z.cloudfront.net/images/NY_199_E_of_Hammertown_2014.jpg');
+  this.render(hbs`{{filestack-image imageToken}}`);
+  let expected = 'https://process.filestackapi.com/AOkSBYOLvTqK3GzWzQMOuz/https://d1wtqaffaaj63z.cloudfront.net/images/NY_199_E_of_Hammertown_2014.jpg';
+  assert.equal(this.$().text().trim(), expected);
+});
+
+test('it handles missing urls', function(assert) {
+  this.set('imageToken', null);
+  this.render(hbs`{{filestack-image imageToken}}`);
+  assert.equal(this.$().text().trim(), '');
+});
+
+test('it handles missing hash arguments', function(assert) {
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken width='200' height='300' fit=crop}}`);
+  let expected = 'https://process.filestackapi.com/resize=width:200,height:300/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});


### PR DESCRIPTION
I had to use some of the newer filestack features and needed an upgraded filestack version. I don't believe there are any breaking changes in the API.