### PR TITLE
Help avoid unnecessary hits to process & invalid requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,29 @@ export default Ember.Component.extend({
 * Complete documentation of all the available options and response data can be found [here](https://www.filestack.com/docs/javascript-api/pick-v3).
 
 
+## Custom CDN
+To minimize your quota usage, you can put filestack behind your own CDNs.
+
+There are two distinct filestack URL's you may want to proxy to.
+
+1. https://process.filestackapi.com
+2. https://cdn.filestackcontent.com
+
+The first is for image transformations (the `{{filestack-image}}` helper lets you easily resize any image -- even arbitrary image URLs). But it renders a URL to that transformation each time, so any time someone visits a page with an image resized (eg https://process.filestackapi.com/resize=width:750/2h25ZGRHTfmQ2DBEt3yR), that will count against your transformation quota. Same for your bandwidth quota, when visiting a page that renders images with https://cdn.filestackcontent.com.
+
+To preserve your quotas, setup two CDNs (eg cloudfront) to point to these URLs. Then configure `ember-filestack` to use your CDNs in ENV:
+```javascript
+module.exports = function(environment) {
+  var ENV = {
+    //...
+    filestackKey: '<your-filestack-key>'
+  filestackProcessCDN: '<your-process-cdn.cloudfront.net>',
+  filestackContentCDN: '<your-content-cdn.cloudfront.net>',
+  };
+```
+
+This way, identical image process or display requests will be cached & come from your CDN, thus saving your quotas on filestack.
+
 
 ## Notes
 In order to have access to the `filestack` instance you can:

--- a/addon/helpers/filestack-image.js
+++ b/addon/helpers/filestack-image.js
@@ -30,6 +30,7 @@ export default Helper.extend({
     if(!token) {
       return '';
     }
+
     if(token.match(/http(s?):\/\//)) {
       imageUrl = token;
       if(this.get('contentUrl') !== defaultContentUrl && imageUrl.match(contentUrlRegex)) {
@@ -41,6 +42,12 @@ export default Helper.extend({
       imageUrl = `${this.get('contentUrl')}/${token}`;
       urlRoot = this.get('processUrl');
     }
+
+    // if there is no width AND no height specified, there's no valid resize to do
+    if(!hash.width && !hash.height) {
+      return imageUrl;
+    }
+
     Object.keys(hash).forEach((key) => {
       let value = hash[key];
       if(value) {
@@ -48,13 +55,7 @@ export default Helper.extend({
       }
     });
 
-    // API requires width or height
-    if(options.length >= 1 && (hash.width || hash.height)) {
-      options = `resize=${options.join(',')}`;
-    } else {
-      // avoid unnecessary hits to transform quota
-      return imageUrl;
-    }
+    options = `resize=${options.join(',')}`;
 
     return [
       urlRoot,

--- a/addon/helpers/filestack-image.js
+++ b/addon/helpers/filestack-image.js
@@ -14,9 +14,16 @@ export default Helper.extend({
   key: alias('config.filestackKey'),
   compute([token], hash) {
     let options = [];
-    let resizeOptions, urlRoot;
+    let resizeOptions, urlRoot, imageUrl;
     if(!token) {
       return '';
+    }
+    if(token.match(/http(s?):\/\//)) {
+      imageUrl = token;
+      urlRoot = `https://process.filestackapi.com/${this.get('key')}`;
+    } else {
+      imageUrl = `https://cdn.filestackcontent.com/${token}`;
+      urlRoot = 'https://process.filestackapi.com';
     }
     Object.keys(hash).forEach((key) => {
       let value = hash[key];
@@ -25,17 +32,13 @@ export default Helper.extend({
       }
     });
 
-    if(options.length >= 1) {
+    // API requires width or height
+    if(options.length >= 1 && (hash.width || hash.height)) {
       resizeOptions = `resize=${options.join(',')}`;
     } else {
-      resizeOptions = null;
+      return imageUrl;
     }
 
-    if(token.match(/http(s?):\/\//)) {
-      urlRoot = `https://process.filestackapi.com/${this.get('key')}`;
-    } else {
-      urlRoot = 'https://process.filestackapi.com';
-    }
     return [
       urlRoot,
       resizeOptions,

--- a/testem.js
+++ b/testem.js
@@ -14,8 +14,11 @@ module.exports = {
       args: [
         '--disable-gpu',
         '--headless',
-        '--remote-debugging-port=0',
-        '--window-size=1440,900'
+        '--window-size=1440,900',
+        "--remote-debugging-port=9222",
+        "--remote-debugging-address=0.0.0.0",
+        "--no-sandbox",
+        "--user-data-dir=/tmp"
       ]
     }
   }

--- a/tests/integration/helpers/filestack-image-test.js
+++ b/tests/integration/helpers/filestack-image-test.js
@@ -5,7 +5,6 @@ moduleForComponent('filestack-image', 'helper:filestack-image', {
   integration: true
 });
 
-// Replace this with your real tests.
 test('it renders a resize with options', function(assert) {
   this.set('imageToken', '123ABC');
   this.render(hbs`{{filestack-image imageToken width='200' height='300' fit='crop'}}`);
@@ -13,17 +12,17 @@ test('it renders a resize with options', function(assert) {
   assert.equal(this.$().text().trim(), expected);
 });
 
-test('it renders a resize without options', function(assert) {
+test('it renders a link to cdn.filestackcontent.com without options', function(assert) {
   this.set('imageToken', '123ABC');
   this.render(hbs`{{filestack-image imageToken}}`);
-  let expected = 'https://process.filestackapi.com/123ABC';
+  let expected = 'https://cdn.filestackcontent.com/123ABC';
   assert.equal(this.$().text().trim(), expected);
 });
 
 test('it handles urls', function(assert) {
-  this.set('imageToken', 'https://d1wtqaffaaj63z.cloudfront.net/images/NY_199_E_of_Hammertown_2014.jpg');
-  this.render(hbs`{{filestack-image imageToken}}`);
-  let expected = 'https://process.filestackapi.com/AOkSBYOLvTqK3GzWzQMOuz/https://d1wtqaffaaj63z.cloudfront.net/images/NY_199_E_of_Hammertown_2014.jpg';
+  let expected = 'https://d1wtqaffaaj63z.cloudfront.net/images/NY_199_E_of_Hammertown_2014.jpg';
+  this.set('imageUrl', expected);
+  this.render(hbs`{{filestack-image imageUrl}}`);
   assert.equal(this.$().text().trim(), expected);
 });
 
@@ -38,5 +37,46 @@ test('it handles missing hash arguments', function(assert) {
   this.set('imageToken', '123ABC');
   this.render(hbs`{{filestack-image imageToken width='200' height='300' fit=crop}}`);
   let expected = 'https://process.filestackapi.com/resize=width:200,height:300/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});
+
+test('it renders the original URL when options are missing & passed a URL', function(assert) {
+  let imageUrl = 'https://d1wtqaffaaj63z.cloudfront.net/images/NY_199_E_of_Hammertown_2014.jpg';
+  this.set('imageUrl', imageUrl);
+  this.render(hbs`{{filestack-image imageUrl}}`);
+  assert.equal(this.$().text().trim(), imageUrl);
+});
+
+test('it renders using https://cdn.filestackcontent.com/ when options are missing & passed a token', function(assert) {
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken}}`);
+  let expected = 'https://cdn.filestackcontent.com/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});
+
+test('it does not set options if the only option is fit', function(assert) {
+  // resize api requires width and/or height
+  // setting ONLY resize=fit:crop returns a 400
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken fit='crop'}}`);
+  let expected = 'https://cdn.filestackcontent.com/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});
+
+test('it does not set options if the only option is align', function(assert) {
+  // resize api requires width and/or height
+  // setting ONLY resize=align:top returns a 400
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken align='top'}}`);
+  let expected = 'https://cdn.filestackcontent.com/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});
+
+test('it does not set options if the only options are fit & align', function(assert) {
+  // resize api requires width and/or height
+  // setting ONLY resize=align:top returns a 400
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken align='top' fit='crop'}}`);
+  let expected = 'https://cdn.filestackcontent.com/123ABC';
   assert.equal(this.$().text().trim(), expected);
 });


### PR DESCRIPTION
1. Unnecessary hits to process are any hits that have no resize options.  When the helper is used without resize options, it should simply return either the URL passed to it (if passed a URL), or a URL to https://cdn.filestackcontent.com/token
2. Prevent invalid requests by ensuring either `width` or `height` is present in the resize options. Otherwise return simple image url.
3. Support custom CDNs for transform & display of images from filestack. This can make your quota last longer.