### PR TITLE
Extract filestack URL building into the filestack service

### DIFF
--- a/addon/helpers/filestack-image.js
+++ b/addon/helpers/filestack-image.js
@@ -7,7 +7,7 @@ const {
 
 export default Helper.extend({
   filestack: service(),
-  compute([token], hash) {
-    return this.get('filestack').buildUrl(token, hash);
+  compute([handleOrUrl], transformations) {
+    return this.get('filestack').imageUrl(handleOrUrl, transformations);
   }
 });

--- a/addon/helpers/filestack-image.js
+++ b/addon/helpers/filestack-image.js
@@ -1,68 +1,13 @@
 import Ember from 'ember';
 
 const {
-  computed,
-  computed: { reads },
-  getOwner,
   Helper,
+  inject: { service },
 } = Ember;
 
-const defaultProcessUrl = "https://process.filestackapi.com";
-const defaultContentUrl = "https://cdn.filestackcontent.com";
-const contentUrlRegex = new RegExp(defaultContentUrl);
-
 export default Helper.extend({
-  config: computed(function() {
-    return getOwner(this).resolveRegistration('config:environment');
-  }),
-  key: reads('config.filestackKey'),
-  customProcessUrl: reads('config.filestackProcessCDN'),
-  customContentUrl: reads('config.filestackContentCDN'),
-  processUrl: computed(function(){
-    return this.get('customProcessUrl') || defaultProcessUrl;
-  }),
-  contentUrl: computed(function() {
-    return this.get('customContentUrl') || defaultContentUrl;
-  }),
+  filestack: service(),
   compute([token], hash) {
-    let options = [];
-    let urlRoot, imageUrl;
-    if(!token) {
-      return '';
-    }
-
-    if(token.match(/http(s?):\/\//)) {
-      imageUrl = token;
-      if(this.get('contentUrl') !== defaultContentUrl && imageUrl.match(contentUrlRegex)) {
-        // avoid unnecessary hits to bandwitch quota
-        imageUrl = imageUrl.replace(defaultContentUrl, this.get('contentUrl'));
-      }
-      urlRoot = `${this.get('processUrl')}/${this.get('key')}`;
-    } else {
-      imageUrl = `${this.get('contentUrl')}/${token}`;
-      urlRoot = this.get('processUrl');
-    }
-
-    // if there is no width AND no height specified, there's no valid resize to do
-    if(!hash.width && !hash.height) {
-      return imageUrl;
-    }
-
-    Object.keys(hash).forEach((key) => {
-      let value = hash[key];
-      if(value) {
-        options.push(`${key}:${value}`);
-      }
-    });
-
-    options = `resize=${options.join(',')}`;
-
-    return [
-      urlRoot,
-      options,
-      token,
-    ].filter((element) => {
-      return element;
-    }).join('/');
+    return this.get('filestack').buildUrl(token, hash);
   }
 });

--- a/addon/services/filestack.js
+++ b/addon/services/filestack.js
@@ -2,19 +2,98 @@ import Ember from 'ember';
 import filestack from 'filestack';
 
 const {
-	computed,
-	computed: { alias },
+	computed: { reads },
 	getOwner,
-	on,
+	getProperties,
 	run: { later },
 	RSVP: { Promise }
 } = Ember;
 
+const defaultContentCDN = "https://cdn.filestackcontent.com";
+const defaultContentCDNRegex = new RegExp(defaultContentCDN);
+
+const defaultConfig = {
+	filestackProcessCDN: "https://process.filestackapi.com",
+	filestackContentCDN: defaultContentCDN,
+	filestackLoadTimeout: 10000,
+};
+
+const configurationKeys = [
+	'filestackContentCDN',
+	'filestackKey',
+	'filestackLoadTimeout',
+	'filestackProcessCDN',
+]
+
 export default Ember.Service.extend({
 	promise: null,
 	instance: null,
+	key: reads('config.filestackKey'),
+  processCDN: reads('config.filestackProcessCDN'),
+  contentCDN: reads('config.filestackContentCDN'),
+	loadTimeout: reads('config.filestackLoadTimeout'),
 
-	_initFilestack: on('init', function() {
+	init() {
+		this._super(...arguments);
+		this._loadConfig();
+		this._initFilestack();
+	},
+
+	buildUrl(token, hash={}) {
+    let options = [];
+		let urlRoot, imageUrl;
+
+    if(!token) {
+      return '';
+		}
+
+    if(token.match(/http(s?):\/\//)) {
+      imageUrl = token;
+      if(this.get('contentCDN') !== defaultContentCDN && imageUrl.match(defaultContentCDNRegex)) {
+        // avoid unnecessary hits to bandwitch quota
+        imageUrl = imageUrl.replace(defaultContentCDN, this.get('contentCDN'));
+      }
+      urlRoot = `${this.get('processCDN')}/${this.get('key')}`;
+    } else {
+      imageUrl = `${this.get('contentCDN')}/${token}`;
+      urlRoot = this.get('processCDN');
+    }
+
+    // if there is no width AND no height specified, there's no valid resize to do
+    if(!hash.width && !hash.height) {
+      return imageUrl;
+    }
+
+    Object.keys(hash).forEach((key) => {
+      let value = hash[key];
+      if(value) {
+        options.push(`${key}:${value}`);
+      }
+    });
+
+		options = `resize=${options.join(',')}`;
+		imageUrl = [ urlRoot, options, token ].filter((element) => element).join('/');
+
+    return imageUrl;
+	},
+
+	_loadConfig() {
+		let env = getOwner(this).resolveRegistration('config:environment');
+		let config = getProperties(env, ...configurationKeys);
+		let mergedConfig = {};
+
+		// clean out `config` since `getProperties` will return an object with valueless keys
+		configurationKeys.forEach((key) => (config[key] == null) && delete config[key]);
+
+		// cannot use `assign` since it is unavailable in Ember 2.4
+		configurationKeys.forEach((key) => {
+			mergedConfig[key] = config[key] || defaultConfig[key];
+		});
+
+		this.set('config', mergedConfig);
+	},
+
+	_initFilestack: function() {
 		var _isPromiseFulfilled = false;
 
 		this.set('promise', new Promise((resolve, reject)=> {
@@ -44,15 +123,5 @@ export default Ember.Service.extend({
 				}
 			}, this.get('loadTimeout'));
 		}));
-	}),
-
-  config: computed(function() {
-    return getOwner(this).resolveRegistration('config:environment');
-  }),
-
-	key: alias('config.filestackKey'),
-
-	loadTimeout: computed('config.filestackLoadTimeout', function() {
-    return this.get('config.filestackLoadTimeout') || 10000;
-  })
+	},
 });

--- a/tests/integration/helpers/filestack-image-test.js
+++ b/tests/integration/helpers/filestack-image-test.js
@@ -153,3 +153,10 @@ test('it uses the config.filestackContentCDN when passed an image token', functi
   const expected = `${contentUrl}/678qwer`;
   assert.equal(this.$().text().trim(), expected);
 });
+
+test('it renders a rotate with options', function(assert) {
+  this.set('imageToken', '123ABC');
+  this.render(hbs`{{filestack-image imageToken rotate=(hash deg=38 exif='false')}}`);
+  let expected = 'https://process.filestackapi.com/rotate=deg:38,exif:false/123ABC';
+  assert.equal(this.$().text().trim(), expected);
+});

--- a/tests/unit/services/filestack-test.js
+++ b/tests/unit/services/filestack-test.js
@@ -1,8 +1,18 @@
 import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
+const {
+  set,
+  getOwner,
+} = Ember;
+
 moduleFor('service:filestack', 'Unit | Service | filestack', {
-  needs: ['config:environment']
+  needs: ['config:environment'],
+  beforeEach: function() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    set(config, 'filestackContentCDN', null);
+    set(config, 'filestackProcessCDN', null);
+  },
 });
 
 test('it exists', function (assert) {
@@ -31,6 +41,6 @@ test('it returns a proper filepicker instance', function (assert) {
 
 test('it builds a filestack URL', function(assert) {
   var service = this.subject();
-  let expected = 'https://mycontent.cloudfront.com/123ABC';
-  assert.equal(service.buildUrl("123ABC"), expected);
+  let expected = 'https://cdn.filestackcontent.com/123ABC';
+  assert.equal(service.imageUrl("123ABC"), expected);
 });

--- a/tests/unit/services/filestack-test.js
+++ b/tests/unit/services/filestack-test.js
@@ -28,3 +28,9 @@ test('it returns a proper filepicker instance', function (assert) {
     assert.equal(service.get('instance'), filepicker, "'instance' value is the resolved filepicker object");
   });
 });
+
+test('it builds a filestack URL', function(assert) {
+  var service = this.subject();
+  let expected = 'https://mycontent.cloudfront.com/123ABC';
+  assert.equal(service.buildUrl("123ABC"), expected);
+});


### PR DESCRIPTION
We recently ran into an issue in which we needed to generate a filestack URL within a component. I extracted the main body of the `filestack-image` helper into the `filestack` service so that we can just inject the service and call `buildUrl`.