### PR TITLE
use angle bracket invocation in tests

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -19,7 +19,8 @@ module.exports = function() {
           npm: {
             devDependencies: {
               '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0'
+              'ember-source': '~2.18.0',
+              'ember-angle-bracket-invocation-polyfill': '^1.2.5'
             }
           }
         },

--- a/tests/integration/components/filestack-picker/component-test.js
+++ b/tests/integration/components/filestack-picker/component-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | filestack picker', function(hooks) {
   test('it renders', async function(assert) {
 
     await render(hbs`
-      {{filestack-picker}}
+      <FilestackPicker/>
     `);
 
     await waitFor('.fsp-picker');
@@ -26,7 +26,7 @@ module('Integration | Component | filestack picker', function(hooks) {
     this.set('options', undefined);
 
     await render(hbs`
-      {{filestack-picker options=options}}
+      <FilestackPicker @options={{options}} />
     `);
 
     assert.dom('.fsp-picker').exists({ count: 1 }, 'pick modal is open');
@@ -44,7 +44,7 @@ module('Integration | Component | filestack picker', function(hooks) {
     });
 
     await render(hbs`
-      {{filestack-picker onClose=onClose options=options}}
+      <FilestackPicker @onClose={{onClose}} @options={{options}} />
     `);
 
     assert.dom('.fsp-picker').exists({ count: 1 }, 'pick modal is open');

--- a/tests/integration/components/filestack-preview/component-test.js
+++ b/tests/integration/components/filestack-preview/component-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | filestack preview', function(hooks) {
   test('renders an iframe with filestack preview url', async function(assert) {
 
     await render(hbs`
-      {{filestack-preview handle="01234567890123456789"}}
+      <FilestackPreview @handle="01234567890123456789" />
     `);
 
     await settled();
@@ -21,7 +21,7 @@ module('Integration | Component | filestack preview', function(hooks) {
   test('css argument is reflected on iframe url', async function(assert) {
 
     await render(hbs`
-      {{filestack-preview handle="01234567890123456789" css="background-color: yellow"}}
+      <FilestackPreview @handle="01234567890123456789" @css="background-color: yellow" />
     `);
 
     await settled();


### PR DESCRIPTION
This brings back angle bracket invocation in tests.
On `2.18` we just need to include `ember-angle-bracket-invocation-polyfill`. This way we also make sure that the addon works with the polyfill.