### PR TITLE
fail graciously on incorrect handles

### DIFF
--- a/addon/helpers/filestack-url.js
+++ b/addon/helpers/filestack-url.js
@@ -2,6 +2,7 @@ import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 import { isBlank } from '@ember/utils';
 import { join } from '@ember/runloop';
+import { warn } from '@ember/debug';
 
 export default Helper.extend({
   filestack: service(),
@@ -23,6 +24,13 @@ export default Helper.extend({
       return;
     }
 
-    return this.filestack.getUrl(handleOrUrl, transformations);
+    try {
+      return this.filestack.getUrl(handleOrUrl, transformations);
+    } catch (e) {
+      warn(`An error occurred while trying to generate a filestack url for the handle '${handleOrUrl}'. Is this a valid filestack handle or url? Error: ${e}`, {
+        id: 'ember-filestack.filestack-url-generation'
+      });
+      return '';
+    }
   }
 });


### PR DESCRIPTION
This makes the `{{filestack-url}}` helper a bit more "forgiving".
I can across a situation where I was passing in an invalid handle to the helper. The filestack.js library throws an error and that makes the helper fail as well.
This makes the whole rendering to fail, leaving the UI in an unusable state.

I think that having a more "forgiving" helper is a sensible thing to do.
We still show the original error and a warning on the console, though.